### PR TITLE
Update test_get_model.py

### DIFF
--- a/tests/test_get_model.py
+++ b/tests/test_get_model.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 import unittest
 import numpy as np
+import tensorflow as tf
 from keras_transformer.backend import keras
 from keras_transformer import get_custom_objects, get_model
 
@@ -24,7 +25,7 @@ class TestGetModel(unittest.TestCase):
             trainable=False,
         )
         model.compile(
-            optimizer=keras.optimizers.Adam(),
+            optimizer=tf.keras.optimizers.Adam(),
             loss=keras.losses.categorical_crossentropy,
             metrics={},
         )
@@ -52,7 +53,7 @@ class TestGetModel(unittest.TestCase):
             use_same_embed=False,
         )
         model.compile(
-            optimizer=keras.optimizers.Adam(),
+            optimizer=tf.keras.optimizers.Adam(),
             loss=keras.losses.categorical_crossentropy,
             metrics={},
         )


### PR DESCRIPTION
This PR aims to fix flaky test `tests/test_get_model.py`. It is flaky depending on the version of python, and the original usage `keras.optimizers.Adam(lr=1e-3)` is no longer valid in python 3.7. We can replace it with `tf.keras.optimizers.Adam(lr=1e-3)`.
The error can be reproduced by `pytest tests/test_get_model.py`.